### PR TITLE
Fix segmentation fault with Python 3.10.1

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,4 +1,3 @@
-
 module Main where
 
 import Foreign.C.Types
@@ -29,7 +28,6 @@ main = do
   lookupEnv "PTGHCI_ENGINE_MODE" >>= \case
     Just _ -> runEngineMode env sockets
     Nothing -> runPythonInProc env sockets
-  
 
 -- | The normal way we run -- Python interpreter runs prompt-toolkit loop
 -- in-process.
@@ -50,10 +48,9 @@ runPythonInProc env sockets = do
 runEngineMode :: Env -> Sockets -> IO ()
 runEngineMode env sockets = do
   sockAddrs <- socketEndpoints sockets
-  
+
   -- Print the socket addresses so Python knows how to connect
   print sockAddrs >> hFlush stdout
 
   (appThread, quitApp) <- runApp env sockets
   wait appThread `finally` quitApp
-

--- a/ptghci.cabal
+++ b/ptghci.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: a0ebeee557bcae5447a22a1ffd65d8a3970b134768d70b872738262849e4de1d
+-- hash: af5d4c08d5bdf87ae8de1c143eb468cfd7280e01f5163ee7953c86d6bc265b0b
 
 name:           ptghci
 version:        0.1.0.0
@@ -82,7 +82,33 @@ library
       Paths_ptghci
   hs-source-dirs:
       src
-  default-extensions: BangPatterns ScopedTypeVariables MultiParamTypeClasses ScopedTypeVariables OverloadedStrings OverloadedLists KindSignatures DataKinds PolyKinds FlexibleInstances DeriveGeneric RecordWildCards DuplicateRecordFields FlexibleContexts DeriveFunctor TypeOperators GeneralizedNewtypeDeriving TypeFamilies TupleSections NamedFieldPuns RankNTypes TypeApplications StandaloneDeriving NoImplicitPrelude ExtendedDefaultRules LambdaCase
+  default-extensions:
+      BangPatterns
+      ScopedTypeVariables
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      OverloadedStrings
+      OverloadedLists
+      KindSignatures
+      DataKinds
+      PolyKinds
+      FlexibleInstances
+      DeriveGeneric
+      RecordWildCards
+      DuplicateRecordFields
+      FlexibleContexts
+      DeriveFunctor
+      TypeOperators
+      GeneralizedNewtypeDeriving
+      TypeFamilies
+      TupleSections
+      NamedFieldPuns
+      RankNTypes
+      TypeApplications
+      StandaloneDeriving
+      NoImplicitPrelude
+      ExtendedDefaultRules
+      LambdaCase
   build-depends:
       aeson
     , ansi-terminal
@@ -123,7 +149,33 @@ executable ptghci
       Paths_ptghci
   hs-source-dirs:
       app
-  default-extensions: BangPatterns ScopedTypeVariables MultiParamTypeClasses ScopedTypeVariables OverloadedStrings OverloadedLists KindSignatures DataKinds PolyKinds FlexibleInstances DeriveGeneric RecordWildCards DuplicateRecordFields FlexibleContexts DeriveFunctor TypeOperators GeneralizedNewtypeDeriving TypeFamilies TupleSections NamedFieldPuns RankNTypes TypeApplications StandaloneDeriving NoImplicitPrelude ExtendedDefaultRules LambdaCase
+  default-extensions:
+      BangPatterns
+      ScopedTypeVariables
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      OverloadedStrings
+      OverloadedLists
+      KindSignatures
+      DataKinds
+      PolyKinds
+      FlexibleInstances
+      DeriveGeneric
+      RecordWildCards
+      DuplicateRecordFields
+      FlexibleContexts
+      DeriveFunctor
+      TypeOperators
+      GeneralizedNewtypeDeriving
+      TypeFamilies
+      TupleSections
+      NamedFieldPuns
+      RankNTypes
+      TypeApplications
+      StandaloneDeriving
+      NoImplicitPrelude
+      ExtendedDefaultRules
+      LambdaCase
   ghc-options: -threaded -rtsopts -with-rtsopts=-N1
   build-depends:
       aeson
@@ -162,7 +214,33 @@ test-suite ptghci-test
       Paths_ptghci
   hs-source-dirs:
       test
-  default-extensions: BangPatterns ScopedTypeVariables MultiParamTypeClasses ScopedTypeVariables OverloadedStrings OverloadedLists KindSignatures DataKinds PolyKinds FlexibleInstances DeriveGeneric RecordWildCards DuplicateRecordFields FlexibleContexts DeriveFunctor TypeOperators GeneralizedNewtypeDeriving TypeFamilies TupleSections NamedFieldPuns RankNTypes TypeApplications StandaloneDeriving NoImplicitPrelude ExtendedDefaultRules LambdaCase
+  default-extensions:
+      BangPatterns
+      ScopedTypeVariables
+      MultiParamTypeClasses
+      ScopedTypeVariables
+      OverloadedStrings
+      OverloadedLists
+      KindSignatures
+      DataKinds
+      PolyKinds
+      FlexibleInstances
+      DeriveGeneric
+      RecordWildCards
+      DuplicateRecordFields
+      FlexibleContexts
+      DeriveFunctor
+      TypeOperators
+      GeneralizedNewtypeDeriving
+      TypeFamilies
+      TupleSections
+      NamedFieldPuns
+      RankNTypes
+      TypeApplications
+      StandaloneDeriving
+      NoImplicitPrelude
+      ExtendedDefaultRules
+      LambdaCase
   ghc-options: -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck

--- a/src/Language/Haskell/PtGhci/StartPy.hs
+++ b/src/Language/Haskell/PtGhci/StartPy.hs
@@ -34,7 +34,6 @@ startPythonApp env (requestAddr, controlAddr, iopubAddr) = do
   setEnv "PTGHCI_REQUEST_ADDR" requestAddr
   setEnv "PTGHCI_CONTROL_ADDR" controlAddr
   setEnv "PTGHCI_IOPUB_ADDR" iopubAddr
-  printDebugInfo env
   s <- newCString $ unlines [ "import os, sys"
                              ,"from ptghci.app import App"
                              ,"app = App()"
@@ -48,6 +47,7 @@ startPythonApp env (requestAddr, controlAddr, iopubAddr) = do
   where
     runPy s done = do
       pyInitialize
+      printDebugInfo env
       res <- pyRunSimpleString s
       when (res == -1) $
         logerr env $ "Python exited with an exception"
@@ -72,7 +72,7 @@ startPythonApp env (requestAddr, controlAddr, iopubAddr) = do
 
 printDebugInfo :: Env -> IO ()
 printDebugInfo env = do
-  debug env $ "Python thread starting"
+  debug env $ "Python thread started"
   pyVer <- pyGetVersion >>= peekCString
   pyPath <- pyGetPath >>= peekCWString
   debug env $ "Python version " ++ pyVer


### PR DESCRIPTION
PtGhci doesn't work anymore on my machine after I updated to Python 3.10.1. This MR introduces a fix for the segmentation fault.